### PR TITLE
typo fix (' -> `); inserted 'https://' to make it an external link.

### DIFF
--- a/eww/isobar/README.md
+++ b/eww/isobar/README.md
@@ -6,9 +6,9 @@
 
 2. Many of the scripts require specific paths which likely differ from system-to-system so test and inspect each script to determine where changes need to be made.
 
-3. Colors are imported into `eww.scss` and the colors of images are changed after running the update_colors script. This script assumes you are using one of my Triangle wallpapers (`Wallpaper/Triangle'). Keep the name formatting the same or edit the script for the colors you want. 
+3. Colors are imported into `eww.scss` and the colors of images are changed after running the update_colors script. This script assumes you are using one of my Triangle wallpapers (`Wallpaper/Triangle`). Keep the name formatting the same or edit the script for the colors you want. 
 
-4. Add your weather Key/ID from [Open Weather Map](openweathermap.org/) to `scripts/weather`.
+4. Add your weather Key/ID from [Open Weather Map](https://openweathermap.org/) to `scripts/weather`.
 ---
 ### Additional Notes:
 


### PR DESCRIPTION
- I fixed a markdown typo (was ' instead of `)
- made the `openweathermap.org` link external (so it will work as intended, instead of pointing to a non-existent location)